### PR TITLE
Fix reload bug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,8 @@ const RowFlex = styled.div`
   display: flex;
   gap: 10%;
   align-items: flex-start;
-  margin-bottom: 10px;`
+  margin-bottom: 10px;
+  flex-wrap: wrap;`
 
 function App() {
   return (

--- a/src/components/bannerInfo/BannerInfo.tsx
+++ b/src/components/bannerInfo/BannerInfo.tsx
@@ -102,19 +102,17 @@ export const BannerInfo = (props: BannerInfoProps) => {
   }
 
   const doTenPull = () => {
+    dispatch(pitySetter(pity + 10));
     if (fates >= 10) {
       dispatch(fatesSetter(fates - 10));
-      dispatch(pitySetter(pity + 10));
     } else if (fates > 0) {
       let primosToMakeDifference = 1600 - (fates * 160);
       if (primos >= primosToMakeDifference) {
         dispatch(fatesSetter(0));
         dispatch(setPrimogems(primos - primosToMakeDifference));
-        dispatch(pitySetter(pity + 10));
       }
     } else if (primos >= 1600) {
       dispatch(setPrimogems(primos - 1600));
-      dispatch(pitySetter(pity + 10));
     }
   }
 

--- a/src/components/bannerInfo/BannerInfo.tsx
+++ b/src/components/bannerInfo/BannerInfo.tsx
@@ -157,7 +157,7 @@ export const BannerInfo = (props: BannerInfoProps) => {
           dispatch(weaponBannerTenPullWithFatesAction(payload));
           break;
         case BannerType.STANDARD:
-          dispatch(standardBannerPullWithFatesAction(payload));
+          dispatch(standardBannerTenPullWithFatesAction(payload));
           break;
       }
       

--- a/src/components/bannerInfo/BannerInfo.tsx
+++ b/src/components/bannerInfo/BannerInfo.tsx
@@ -6,7 +6,22 @@ import { useSelector, useDispatch } from 'react-redux';
 import type { ActionCreatorWithPayload } from '@reduxjs/toolkit';
 import { 
   selectPrimogems,
-  setPrimogems
+  setPrimogems,
+  characterBannerTenPullWithFatesAndPrimosAction,
+  characterBannerTenPullWithFatesAction,
+  characterBannerTenPullWithPrimosAction,
+  characterBannerPullWithFatesAction,
+  characterBannerPullWithPrimosAction,
+  weaponBannerTenPullWithFatesAndPrimosAction,
+  weaponBannerTenPullWithFatesAction,
+  weaponBannerTenPullWithPrimosAction,
+  weaponBannerPullWithFatesAction,
+  weaponBannerPullWithPrimosAction,
+  standardBannerTenPullWithFatesAndPrimosAction,
+  standardBannerTenPullWithFatesAction,
+  standardBannerTenPullWithPrimosAction,
+  standardBannerPullWithFatesAction,
+  standardBannerPullWithPrimosAction,
 } from '../../store/slices/bannerDataSlice';
 import { useEffect, useState } from 'react';
 
@@ -94,25 +109,95 @@ export const BannerInfo = (props: BannerInfoProps) => {
   // event handlers for the single and ten pull buttons
   const doSinglePull = () => {
     if (fates >= 1) {
-      dispatch(fatesSetter(fates - 1));
+      const payload = {
+        pity: pity + 1,
+        fates: fates - 1
+      }
+      switch(type) {
+        case BannerType.CHARACTER:
+          dispatch(characterBannerPullWithFatesAction(payload));
+          break;
+        case BannerType.WEAPON:
+          dispatch(weaponBannerPullWithFatesAction(payload));
+          break;
+        case BannerType.STANDARD:
+          dispatch(standardBannerPullWithFatesAction(payload));
+          break;
+      }
     } else if (primos >= 160) {
-      dispatch(setPrimogems(primos - 160));
+      const payload = {
+        pity: pity + 1,
+        primos: primos - 1
+      }
+      switch(type) {
+        case BannerType.CHARACTER:
+          dispatch(characterBannerPullWithPrimosAction(payload));
+          break;
+        case BannerType.WEAPON:
+          dispatch(weaponBannerPullWithPrimosAction(payload));
+          break;
+        case BannerType.STANDARD:
+          dispatch(standardBannerPullWithPrimosAction(payload));
+          break;
+      }
     }
-    dispatch(pitySetter(pity + 1))
   }
 
   const doTenPull = () => {
-    dispatch(pitySetter(pity + 10));
     if (fates >= 10) {
-      dispatch(fatesSetter(fates - 10));
+      const payload = {
+        pity: pity + 10,
+        fates: fates - 10
+      };
+      switch(type) {
+        case BannerType.CHARACTER:
+          dispatch(characterBannerTenPullWithFatesAction(payload));
+          break;
+        case BannerType.WEAPON:
+          dispatch(weaponBannerTenPullWithFatesAction(payload));
+          break;
+        case BannerType.STANDARD:
+          dispatch(standardBannerPullWithFatesAction(payload));
+          break;
+      }
+      
     } else if (fates > 0) {
       let primosToMakeDifference = 1600 - (fates * 160);
       if (primos >= primosToMakeDifference) {
-        dispatch(fatesSetter(0));
-        dispatch(setPrimogems(primos - primosToMakeDifference));
+        const payload = {
+          pity: pity + 10,
+          fates: 0,
+          primos: primos - primosToMakeDifference
+        }
+        switch(type) {
+          case BannerType.CHARACTER:
+            dispatch(characterBannerTenPullWithFatesAndPrimosAction(payload));
+            break;
+          case BannerType.WEAPON:
+            dispatch(weaponBannerTenPullWithFatesAndPrimosAction(payload));
+            break;
+          case BannerType.STANDARD:
+            dispatch(standardBannerTenPullWithFatesAndPrimosAction(payload));
+            break;
+        }
       }
     } else if (primos >= 1600) {
-      dispatch(setPrimogems(primos - 1600));
+      const payload = {
+        pity: pity + 10,
+        primos: primos - 1600
+      };
+
+      switch(type) {
+        case BannerType.CHARACTER:
+          dispatch(characterBannerTenPullWithPrimosAction(payload));
+          break;
+        case BannerType.WEAPON:
+          dispatch(weaponBannerTenPullWithPrimosAction(payload));
+          break;
+        case BannerType.STANDARD:
+          dispatch(standardBannerTenPullWithPrimosAction(payload));
+          break;
+      }
     }
   }
 

--- a/src/components/bannerInfo/BannerInfo.tsx
+++ b/src/components/bannerInfo/BannerInfo.tsx
@@ -4,25 +4,7 @@ import { Button } from '../SharedComponents';
 import type { RootState } from '../../store/store';
 import { useSelector, useDispatch } from 'react-redux';
 import type { ActionCreatorWithPayload } from '@reduxjs/toolkit';
-import { 
-  selectPrimogems,
-  setPrimogems,
-  characterBannerTenPullWithFatesAndPrimosAction,
-  characterBannerTenPullWithFatesAction,
-  characterBannerTenPullWithPrimosAction,
-  characterBannerPullWithFatesAction,
-  characterBannerPullWithPrimosAction,
-  weaponBannerTenPullWithFatesAndPrimosAction,
-  weaponBannerTenPullWithFatesAction,
-  weaponBannerTenPullWithPrimosAction,
-  weaponBannerPullWithFatesAction,
-  weaponBannerPullWithPrimosAction,
-  standardBannerTenPullWithFatesAndPrimosAction,
-  standardBannerTenPullWithFatesAction,
-  standardBannerTenPullWithPrimosAction,
-  standardBannerPullWithFatesAction,
-  standardBannerPullWithPrimosAction,
-} from '../../store/slices/bannerDataSlice';
+import { selectPrimogems } from '../../store/slices/bannerDataSlice';
 import { useEffect, useState } from 'react';
 
 const ColumnFlex = styled.div`
@@ -48,7 +30,7 @@ const Text = styled.p`
 
 const BlueText = styled.span`
     color: #0d6efd;`;
-  
+
 const Input = styled.input`
   max-width: 500px;
   padding: 7px;
@@ -66,11 +48,25 @@ export interface BannerInfoProps {
   pitySelector: (state: RootState) => number;
   pitySetter: ActionCreatorWithPayload<number, string>;
   fatesSelector: (state: RootState) => number;
-  fatesSetter: ActionCreatorWithPayload<number, string>,
+  bannerTenPullWithFatesAndPrimosAction: ActionCreatorWithPayload<{ pity: number, fates: number, primos: number }>;
+  bannerTenPullWithFatesAction: ActionCreatorWithPayload<{ pity: number, fates: number }>;
+  bannerTenPullWithPrimosAction: ActionCreatorWithPayload<{ pity: number, primos: number }>;
+  bannerPullWithFatesAction: ActionCreatorWithPayload<{ pity: number, fates: number }>;
+  bannerPullWithPrimosAction: ActionCreatorWithPayload<{ pity: number, primos: number }>;
 }
 
 export const BannerInfo = (props: BannerInfoProps) => {
-  const { type, pitySelector, pitySetter, fatesSelector, fatesSetter } = props;
+  const {
+    type,
+    pitySelector,
+    pitySetter,
+    fatesSelector,
+    bannerTenPullWithFatesAndPrimosAction,
+    bannerTenPullWithFatesAction,
+    bannerTenPullWithPrimosAction,
+    bannerPullWithFatesAction,
+    bannerPullWithPrimosAction
+  } = props;
 
   const dispatch = useDispatch();
   const pity = useSelector(pitySelector);
@@ -113,33 +109,13 @@ export const BannerInfo = (props: BannerInfoProps) => {
         pity: pity + 1,
         fates: fates - 1
       }
-      switch(type) {
-        case BannerType.CHARACTER:
-          dispatch(characterBannerPullWithFatesAction(payload));
-          break;
-        case BannerType.WEAPON:
-          dispatch(weaponBannerPullWithFatesAction(payload));
-          break;
-        case BannerType.STANDARD:
-          dispatch(standardBannerPullWithFatesAction(payload));
-          break;
-      }
+      dispatch(bannerPullWithFatesAction(payload));
     } else if (primos >= 160) {
       const payload = {
         pity: pity + 1,
-        primos: primos - 1
+        primos: primos - 160
       }
-      switch(type) {
-        case BannerType.CHARACTER:
-          dispatch(characterBannerPullWithPrimosAction(payload));
-          break;
-        case BannerType.WEAPON:
-          dispatch(weaponBannerPullWithPrimosAction(payload));
-          break;
-        case BannerType.STANDARD:
-          dispatch(standardBannerPullWithPrimosAction(payload));
-          break;
-      }
+      dispatch(bannerPullWithPrimosAction(payload));
     }
   }
 
@@ -149,18 +125,7 @@ export const BannerInfo = (props: BannerInfoProps) => {
         pity: pity + 10,
         fates: fates - 10
       };
-      switch(type) {
-        case BannerType.CHARACTER:
-          dispatch(characterBannerTenPullWithFatesAction(payload));
-          break;
-        case BannerType.WEAPON:
-          dispatch(weaponBannerTenPullWithFatesAction(payload));
-          break;
-        case BannerType.STANDARD:
-          dispatch(standardBannerTenPullWithFatesAction(payload));
-          break;
-      }
-      
+      dispatch(bannerTenPullWithFatesAction(payload));
     } else if (fates > 0) {
       let primosToMakeDifference = 1600 - (fates * 160);
       if (primos >= primosToMakeDifference) {
@@ -169,35 +134,14 @@ export const BannerInfo = (props: BannerInfoProps) => {
           fates: 0,
           primos: primos - primosToMakeDifference
         }
-        switch(type) {
-          case BannerType.CHARACTER:
-            dispatch(characterBannerTenPullWithFatesAndPrimosAction(payload));
-            break;
-          case BannerType.WEAPON:
-            dispatch(weaponBannerTenPullWithFatesAndPrimosAction(payload));
-            break;
-          case BannerType.STANDARD:
-            dispatch(standardBannerTenPullWithFatesAndPrimosAction(payload));
-            break;
-        }
+        dispatch(bannerTenPullWithFatesAndPrimosAction(payload));
       }
     } else if (primos >= 1600) {
       const payload = {
         pity: pity + 10,
         primos: primos - 1600
       };
-
-      switch(type) {
-        case BannerType.CHARACTER:
-          dispatch(characterBannerTenPullWithPrimosAction(payload));
-          break;
-        case BannerType.WEAPON:
-          dispatch(weaponBannerTenPullWithPrimosAction(payload));
-          break;
-        case BannerType.STANDARD:
-          dispatch(standardBannerTenPullWithPrimosAction(payload));
-          break;
-      }
+      dispatch(bannerTenPullWithPrimosAction(payload));
     }
   }
 
@@ -228,7 +172,7 @@ export const BannerInfo = (props: BannerInfoProps) => {
   return (
     <ColumnFlex>
       <Title>
-        {`${type} Banner`} 
+        {`${type} Banner`}
       </Title>
       <IndentedDiv>
         <RowFlex>
@@ -237,7 +181,7 @@ export const BannerInfo = (props: BannerInfoProps) => {
           <Button disabled={!canDoSinglePull} onClick={doSinglePull}>1 pull</Button>
           <Button disabled={!canDoTenPull} onClick={doTenPull}>10 pull</Button>
         </RowFlex>
-        <TotalPulls>Total pulls on Character Banner: {totalPulls}</TotalPulls>
+        <TotalPulls>Total pulls on {type} Banner: {totalPulls}</TotalPulls>
         <Text>You can hit hard pity {numberOfHardPities} times</Text>
         <Text>You need <BlueText>{primosToNextHardPity}</BlueText> primos to reach your next hard pity</Text>
       </IndentedDiv>

--- a/src/components/bannerInfo/index.tsx
+++ b/src/components/bannerInfo/index.tsx
@@ -1,18 +1,31 @@
 import { BannerType } from '../BannerEnums';
 import { BannerInfo } from './BannerInfo';
 import styled from 'styled-components';
-import { 
+import {
     selectIntertwinedFates,
     selectAcquaintFates,
     selectCharacterBannerPity,
     selectWeaponBannerPity,
-    selectStandardBannerPity,      // TODO: Rename pulls to pity
-    setIntertwinedFates,
-    setAcquaintFates,
+    selectStandardBannerPity,
     setCharacterBannerPity,
     setWeaponBannerPity,
-    setStandardBannerPity
-  } from '../../store/slices/bannerDataSlice';
+    setStandardBannerPity,
+    characterBannerTenPullWithFatesAndPrimosAction,
+    characterBannerTenPullWithFatesAction,
+    characterBannerTenPullWithPrimosAction,
+    characterBannerPullWithFatesAction,
+    characterBannerPullWithPrimosAction,
+    weaponBannerTenPullWithFatesAndPrimosAction,
+    weaponBannerTenPullWithFatesAction,
+    weaponBannerTenPullWithPrimosAction,
+    weaponBannerPullWithFatesAction,
+    weaponBannerPullWithPrimosAction,
+    standardBannerTenPullWithFatesAndPrimosAction,
+    standardBannerTenPullWithFatesAction,
+    standardBannerTenPullWithPrimosAction,
+    standardBannerPullWithFatesAction,
+    standardBannerPullWithPrimosAction,
+} from '../../store/slices/bannerDataSlice';
 
 const FlexColumn = styled.div`
     display: flex;
@@ -22,26 +35,38 @@ const FlexColumn = styled.div`
 const BannerInfoPanel = () => {
     return (
         <FlexColumn>
-            <BannerInfo 
+            <BannerInfo
                 type={BannerType.STANDARD}
                 pitySelector={selectStandardBannerPity}
                 pitySetter={setStandardBannerPity}
                 fatesSelector={selectAcquaintFates}
-                fatesSetter={setAcquaintFates}
+                bannerTenPullWithFatesAndPrimosAction={standardBannerTenPullWithFatesAndPrimosAction}
+                bannerTenPullWithFatesAction={standardBannerTenPullWithFatesAction}
+                bannerTenPullWithPrimosAction={standardBannerTenPullWithPrimosAction}
+                bannerPullWithFatesAction={standardBannerPullWithFatesAction}
+                bannerPullWithPrimosAction={standardBannerPullWithPrimosAction}
             ></BannerInfo>
-            <BannerInfo 
-                type={BannerType.CHARACTER} 
-                pitySelector={selectCharacterBannerPity} 
+            <BannerInfo
+                type={BannerType.CHARACTER}
+                pitySelector={selectCharacterBannerPity}
                 pitySetter={setCharacterBannerPity}
                 fatesSelector={selectIntertwinedFates}
-                fatesSetter={setIntertwinedFates}
+                bannerTenPullWithFatesAndPrimosAction={characterBannerTenPullWithFatesAndPrimosAction}
+                bannerTenPullWithFatesAction={characterBannerTenPullWithFatesAction}
+                bannerTenPullWithPrimosAction={characterBannerTenPullWithPrimosAction}
+                bannerPullWithFatesAction={characterBannerPullWithFatesAction}
+                bannerPullWithPrimosAction={characterBannerPullWithPrimosAction}
             ></BannerInfo>
-            <BannerInfo 
+            <BannerInfo
                 type={BannerType.WEAPON}
                 pitySelector={selectWeaponBannerPity}
                 pitySetter={setWeaponBannerPity}
                 fatesSelector={selectIntertwinedFates}
-                fatesSetter={setIntertwinedFates}
+                bannerTenPullWithFatesAndPrimosAction={weaponBannerTenPullWithFatesAndPrimosAction}
+                bannerTenPullWithFatesAction={weaponBannerTenPullWithFatesAction}
+                bannerTenPullWithPrimosAction={weaponBannerTenPullWithPrimosAction}
+                bannerPullWithFatesAction={weaponBannerPullWithFatesAction}
+                bannerPullWithPrimosAction={weaponBannerPullWithPrimosAction}
             ></BannerInfo>
         </FlexColumn>
     )

--- a/src/components/bannerInfo/index.tsx
+++ b/src/components/bannerInfo/index.tsx
@@ -10,6 +10,9 @@ import {
     setCharacterBannerPity,
     setWeaponBannerPity,
     setStandardBannerPity,
+} from '../../store/slices/bannerDataSlice';
+
+import {
     characterBannerTenPullWithFatesAndPrimosAction,
     characterBannerTenPullWithFatesAction,
     characterBannerTenPullWithPrimosAction,
@@ -24,8 +27,8 @@ import {
     standardBannerTenPullWithFatesAction,
     standardBannerTenPullWithPrimosAction,
     standardBannerPullWithFatesAction,
-    standardBannerPullWithPrimosAction,
-} from '../../store/slices/bannerDataSlice';
+    standardBannerPullWithPrimosAction
+} from '../../store/actions/PullActions';
 
 const FlexColumn = styled.div`
     display: flex;

--- a/src/components/currencyData/FatesInput.tsx
+++ b/src/components/currencyData/FatesInput.tsx
@@ -3,8 +3,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import type { ActionCreatorWithPayload } from '@reduxjs/toolkit';
 import type { RootState } from '../../store/store';
 
-import { BannerCurrency } from '../BannerEnums';
-
 export interface FatesInputProps {
     icon: string;
     selector: (state: RootState) => number,

--- a/src/store/actions/PullActions.ts
+++ b/src/store/actions/PullActions.ts
@@ -1,0 +1,37 @@
+import { createAction } from "@reduxjs/toolkit";
+
+const characterBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('CHARACTER_TEN_PULL_WITH_FATES_AND_PRIMOS');
+const characterBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('CHARACTER_TEN_PULL_WITH_FATES');
+const characterBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('CHARACTER_TEN_PULL_WITH_PRIMOS');
+const characterBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('CHARACTER_PULL_WITH_FATES');
+const characterBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('CHARACTER_PULL_WITH_PRIMOS');
+
+const weaponBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('WEAPON_TEN_PULL_WITH_FATES_AND_PRIMOS');
+const weaponBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('WEAPON_TEN_PULL_WITH_FATES');
+const weaponBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('WEAPON_TEN_PULL_WITH_PRIMOS');
+const weaponBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('WEAPON_PULL_WITH_FATES');
+const weaponBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('WEAPON_PULL_WITH_PRIMOS');
+
+const standardBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('STANDARD_TEN_PULL_WITH_FATES_AND_PRIMOS');
+const standardBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('STANDARD_TEN_PULL_WITH_FATES');
+const standardBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('STANDARD_TEN_PULL_WITH_PRIMOS');
+const standardBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('STANDARD_PULL_WITH_FATES');
+const standardBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('STANDARD_PULL_WITH_PRIMOS');
+
+export {
+    characterBannerTenPullWithFatesAndPrimosAction,
+    characterBannerTenPullWithFatesAction,
+    characterBannerTenPullWithPrimosAction,
+    characterBannerPullWithFatesAction,
+    characterBannerPullWithPrimosAction,
+    weaponBannerTenPullWithFatesAndPrimosAction,
+    weaponBannerTenPullWithFatesAction,
+    weaponBannerTenPullWithPrimosAction,
+    weaponBannerPullWithFatesAction,
+    weaponBannerPullWithPrimosAction,
+    standardBannerTenPullWithFatesAndPrimosAction,
+    standardBannerTenPullWithFatesAction,
+    standardBannerTenPullWithPrimosAction,
+    standardBannerPullWithFatesAction,
+    standardBannerPullWithPrimosAction
+};

--- a/src/store/slices/bannerDataSlice.ts
+++ b/src/store/slices/bannerDataSlice.ts
@@ -1,4 +1,4 @@
-import { createAction, createSlice } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../store';
 import {

--- a/src/store/slices/bannerDataSlice.ts
+++ b/src/store/slices/bannerDataSlice.ts
@@ -1,6 +1,23 @@
 import { createAction, createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../store';
+import {
+    characterBannerTenPullWithFatesAndPrimosAction,
+    characterBannerTenPullWithFatesAction,
+    characterBannerTenPullWithPrimosAction,
+    characterBannerPullWithFatesAction,
+    characterBannerPullWithPrimosAction,
+    weaponBannerTenPullWithFatesAndPrimosAction,
+    weaponBannerTenPullWithFatesAction,
+    weaponBannerTenPullWithPrimosAction,
+    weaponBannerPullWithFatesAction,
+    weaponBannerPullWithPrimosAction,
+    standardBannerTenPullWithFatesAndPrimosAction,
+    standardBannerTenPullWithFatesAction,
+    standardBannerTenPullWithPrimosAction,
+    standardBannerPullWithFatesAction,
+    standardBannerPullWithPrimosAction
+} from '../actions/PullActions';
 
 const initialState = {
     primogems: 0,
@@ -11,23 +28,7 @@ const initialState = {
     standardBannerPity: 0
 };
 
-export const characterBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('CHARACTER_TEN_PULL_WITH_FATES_AND_PRIMOS');
-export const characterBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('CHARACTER_TEN_PULL_WITH_FATES');
-export const characterBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('CHARACTER_TEN_PULL_WITH_PRIMOS');
-export const characterBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('CHARACTER_PULL_WITH_FATES');
-export const characterBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('CHARACTER_PULL_WITH_PRIMOS');
 
-export const weaponBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('WEAPON_TEN_PULL_WITH_FATES_AND_PRIMOS');
-export const weaponBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('WEAPON_TEN_PULL_WITH_FATES');
-export const weaponBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('WEAPON_TEN_PULL_WITH_PRIMOS');
-export const weaponBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('WEAPON_PULL_WITH_FATES');
-export const weaponBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('WEAPON_PULL_WITH_PRIMOS');
-
-export const standardBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('STANDARD_TEN_PULL_WITH_FATES_AND_PRIMOS');
-export const standardBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('STANDARD_TEN_PULL_WITH_FATES');
-export const standardBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('STANDARD_TEN_PULL_WITH_PRIMOS');
-export const standardBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('STANDARD_PULL_WITH_FATES');
-export const standardBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('STANDARD_PULL_WITH_PRIMOS');
 
 const bannerSlice = createSlice({
     name: 'banner',

--- a/src/store/slices/bannerDataSlice.ts
+++ b/src/store/slices/bannerDataSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createAction, createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../store';
 
@@ -10,6 +10,24 @@ const initialState = {
     weaponBannerPity: 0,
     standardBannerPity: 0
 };
+
+export const characterBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('CHARACTER_TEN_PULL_WITH_FATES_AND_PRIMOS');
+export const characterBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('CHARACTER_TEN_PULL_WITH_FATES');
+export const characterBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('CHARACTER_TEN_PULL_WITH_PRIMOS');
+export const characterBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('CHARACTER_PULL_WITH_FATES');
+export const characterBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('CHARACTER_PULL_WITH_PRIMOS');
+
+export const weaponBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('WEAPON_TEN_PULL_WITH_FATES_AND_PRIMOS');
+export const weaponBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('WEAPON_TEN_PULL_WITH_FATES');
+export const weaponBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('WEAPON_TEN_PULL_WITH_PRIMOS');
+export const weaponBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('WEAPON_PULL_WITH_FATES');
+export const weaponBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('WEAPON_PULL_WITH_PRIMOS');
+
+export const standardBannerTenPullWithFatesAndPrimosAction = createAction<{pity: number, fates: number, primos: number}>('STANDARD_TEN_PULL_WITH_FATES_AND_PRIMOS');
+export const standardBannerTenPullWithFatesAction = createAction<{pity: number, fates: number}>('STANDARD_TEN_PULL_WITH_FATES');
+export const standardBannerTenPullWithPrimosAction = createAction<{pity: number, primos: number}>('STANDARD_TEN_PULL_WITH_PRIMOS');
+export const standardBannerPullWithFatesAction = createAction<{pity: number, fates: number}>('STANDARD_PULL_WITH_FATES');
+export const standardBannerPullWithPrimosAction = createAction<{pity: number, primos: number}>('STANDARD_PULL_WITH_PRIMOS');
 
 const bannerSlice = createSlice({
     name: 'banner',
@@ -32,8 +50,89 @@ const bannerSlice = createSlice({
         },
         setStandardBannerPity: (state, action: PayloadAction<number>) => {
             state.standardBannerPity = action.payload > 0 ? action.payload : 0;
-        }
-    }
+        },
+    },
+    extraReducers: (builder) => {
+        builder
+            .addCase(characterBannerTenPullWithFatesAndPrimosAction, (state, action) => {
+                const {pity, fates, primos} = action.payload;
+                state.characterBannerPity = pity;
+                state.intertwinedFates = fates;
+                state.primogems = primos;
+            })
+            .addCase(characterBannerTenPullWithFatesAction, (state, action) => {
+                const {pity, fates} = action.payload;
+                state.characterBannerPity = pity;
+                state.intertwinedFates = fates;
+            })
+            .addCase(characterBannerTenPullWithPrimosAction, (state, action) => {
+                const { pity, primos } = action.payload;
+                state.characterBannerPity = pity;
+                state.primogems = primos;
+            })
+            .addCase(characterBannerPullWithFatesAction, (state, action) => {
+                const { pity, fates } = action.payload;
+                state.characterBannerPity = pity;
+                state.intertwinedFates = fates;
+            })
+            .addCase(characterBannerPullWithPrimosAction, (state, action) => {
+                const { pity, primos } = action.payload;
+                state.characterBannerPity = pity;
+                state.primogems = primos;
+            })
+            .addCase(weaponBannerTenPullWithFatesAndPrimosAction, (state, action) => {
+                const {pity, fates, primos} = action.payload;
+                state.weaponBannerPity = pity;
+                state.intertwinedFates = fates;
+                state.primogems = primos;
+            })
+            .addCase(weaponBannerTenPullWithFatesAction, (state, action) => {
+                const { pity, fates } = action.payload;
+                state.weaponBannerPity = pity;
+                state.intertwinedFates = fates;
+            })
+            .addCase(weaponBannerTenPullWithPrimosAction, (state, action) => {
+                const { pity, primos } = action.payload;
+                state.weaponBannerPity = pity;
+                state.primogems = primos;
+            })
+            .addCase(weaponBannerPullWithFatesAction, (state, action) => {
+                const { pity, fates } = action.payload;
+                state.weaponBannerPity = pity;
+                state.intertwinedFates = fates;
+            })
+            .addCase(weaponBannerPullWithPrimosAction, (state, action) => {
+                const { pity, primos } = action.payload;
+                state.weaponBannerPity = pity;
+                state.primogems = primos;
+            })
+            .addCase(standardBannerTenPullWithFatesAndPrimosAction, (state, action) => {
+                const {pity, fates, primos} = action.payload;
+                state.standardBannerPity = pity;
+                state.acquaintFates = fates;
+                state.primogems = primos;
+            })
+            .addCase(standardBannerTenPullWithFatesAction, (state, action) => {
+                const { pity, fates } = action.payload;
+                state.standardBannerPity = pity;
+                state.acquaintFates = fates;
+            })
+            .addCase(standardBannerTenPullWithPrimosAction, (state, action) => {
+                const { pity, primos } = action.payload;
+                state.standardBannerPity = pity;
+                state.primogems = primos;
+            })
+            .addCase(standardBannerPullWithFatesAction, (state, action) => {
+                const { pity, fates } = action.payload;
+                state.standardBannerPity = pity;
+                state.acquaintFates = fates;
+            })
+            .addCase(standardBannerPullWithPrimosAction, (state, action) => {
+                const { pity, primos } = action.payload;
+                state.standardBannerPity = pity;
+                state.primogems = primos;
+            })
+    },
 });
 
 export const { 


### PR DESCRIPTION
Before this PR if a user reloaded the page immediately after clicking `1 pull` or `10 pull` then the pity counter would not be saved. This was due to the second action being dispatched too slowly.

This PR fixes that by combining the two actions